### PR TITLE
remove google analytics token

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,10 +129,6 @@ extra_javascript:
 extra_css:
   - stylesheets/extra.css
 
-google_analytics:
-  - 'UA-115581982-1'
-  - 'auto'
-
 plugins:
   - search
   - minify:


### PR DESCRIPTION
Please do not use our google property tag on your site as it corrupts our reports.